### PR TITLE
Fix JSON parsing errors

### DIFF
--- a/scli
+++ b/scli
@@ -322,8 +322,10 @@ class Signal:
             if not os.path.exists(self._path):
                 raise Exception(self.user + " does not exist!")
         self._data = self.load_data()
+        self._buffer = b''
 
     def load_data(self):
+        print(self._path)
         with open(self._path) as f:
             return json.load(f)
 
@@ -332,17 +334,29 @@ class Signal:
         return Popen(['signal-cli', '-u', self.user, 'daemon', '--json'], stdout=fd, stderr=fd, close_fds=True)
 
     def daemon_handler(self, line):
-        if not line.strip():
-            return
+        line = self._buffer + line
+        lines = line.split(b'\n')
+        if lines[-1] != b'':
+            # Not a complete message. Store in buffer
+            self._buffer = lines[-1]
+        else:
+            self._buffer = b''
+        
+        # The last item is either empty or an incomplete message, so we don't process it
+        for line in lines[:-1]:
+            if not line.strip():
+                continue
 
-        try:
-            e = json.loads(line)
-        except Exception as e:
-            logging.error('input:%s', line)
-            logging.exception(e)
-            return
+            try:
+                e = json.loads(line)
+                urwid.emit_signal(self, 'receive_message', e['envelope'])
+            except Exception as e:
+                logging.error('input: %s', line)
+                logging.exception(e)
+                urwid.emit_signal(self, 'receive_message', 'Lost message: %r %r' % (line, e))
+                continue
 
-        urwid.emit_signal(self, 'receive_message', e['envelope'])
+            
 
     def send_message(self, contact, message="", attachments=[]):
         args = ['signal-cli', '--dbus', 'send', '--message', message]


### PR DESCRIPTION
Quite a lot of the message I received didn't display in scli. In the log file I got the following errors:
```
ERROR:root:input:b'{"envelope":{"source":"XXX","sourceDevice":1,"relay":null,"timestamp":1551041580751,"isReceipt":false,"dataMessage":null,"syncMessage":null,"callMessage":null}'
ERROR:root:Expecting ',' delimiter: line 1 column 171 (char 170)
Traceback (most recent call last):
  File "./scli", line 342, in daemon_handler
    e = json.loads(line)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 171 (char 170)
ERROR:root:input:b'}'
ERROR:root:Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  File "./scli", line 342, in daemon_handler
    e = json.loads(line)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
As you can see in the first step it tried to decode the message without the closing bracket and then it tries to decode only the closing bracket. Both steps obviously fail.
This is patch waits for a newline character before trying to parse the message. While newlines are valid in JSON they don't appear in the signal-cli output and can be used as an end of message marker.
If parsing fails anyways it at least outputs the unparsable JSON in the message window instead of silently dropping it. (However this never happend during testing.)