### PR TITLE
Filtered out non-active groups from panel

### DIFF
--- a/scli
+++ b/scli
@@ -587,8 +587,10 @@ class Signal:
                            self._data['contactStore']['contacts']))
 
     def groups(self):
-        return list(filter(lambda x: bool(x['name'].strip(' ')),
-                           self._data["groupStore"]['groups']))
+        # Need to filter out any groups that where "active" == false
+        return list(filter(lambda a: bool(a['active']),
+                    (filter(lambda n: bool(n['name'].strip(' ')),
+                     self._data["groupStore"]['groups']))))
 
     def get_contact(self, number_or_id):
         for contact in self.contacts():


### PR DESCRIPTION
Simple enough usability fix.

Background. I use _lots_ of groups to manage topic interactions. They are often ephemeral and once the topic is done I leave the group so my interface is not full of dead groups.

There is an "active" flag on each group, so I filter on that:

```python
    def groups(self):
        # Need to filter out any groups that where "active" == false
        return list(filter(lambda a: bool(a['active']),
                    (filter(lambda n: bool(n['name'].strip(' ')),
                     self._data["groupStore"]['groups']))))
```

Please say if there are any implications of this. I can't think of any.

Great job here.