### PR TITLE
Prevent crash when cmd not given

### DIFF
--- a/scli
+++ b/scli
@@ -882,9 +882,12 @@ class ChatWindow(urwid.Frame):
                 txt = self.get_edit_text()
                 if txt.startswith(':'):
                     elems = list(filter(lambda x: x != '', txt[1:].split(' ')))
-                    cmd = elems[0].lower()
-                    args = elems[1:]
-                    commands.exec(self.state, cmd, args)
+                    try:
+                        cmd = elems[0].lower()
+                        args = elems[1:]
+                        commands.exec(self.state, cmd, args)
+                    except IndexError:
+                        pass
                 elif txt.startswith('/'):
                     pass
                 elif txt.strip(' ') != '' and self.state.current_contact:


### PR DESCRIPTION
Currently if you type : and press enter without completing the cmd, it will crash scli as the elems list will be empty.