### PR TITLE
Decode UTF-8 message to prevent json parsing error

### DIFF
--- a/scli
+++ b/scli
@@ -609,7 +609,7 @@ class Signal:
                 continue
 
             try:
-                e = json.loads(line)
+                e = json.loads(line.decode('utf-8'))
                 urwid.emit_signal(self, 'receive_message', e['envelope'])
             except Exception as e:
                 logging.error('input: %s', line)


### PR DESCRIPTION
Fixes error:
```
Traceback (most recent call last):
  File "/home/legerf/scli/scli", line 612, in daemon_handler
    e = json.loads(line)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```