### PR TITLE
Use urwid_readline for inputs if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Firstly, you need to install [signal-cli](https://github.com/AsamK/signal-cli). Follow the guide provided in the README.
 - Install `libunixsocket-java` from your package manager if you have not installed it yet. (Arch Linux users should install `libmatthew-unix-java` from AUR. If you installed `signal-cli` from AUR, you can skip this step.)
 - Install `urwid`. You can install it trough your distributions package manager (search for `python3-urwid` or `python-urwid`) or you can use `pip` to install: `pip3 install urwid`.
+- (Optional) Install `urwid_readline` if you want readline keybinds while typing. It may be available through your distribution's package manager as `python3-urwid_readline` or `python-urwid_readline`, or you can install it through `pip` with `pip install urwid_readline`
 
 ## Linking your device and using
 `scli` does not provide anything for registering/linking, you need to do this using `signal-cli`.

--- a/scli
+++ b/scli
@@ -19,6 +19,12 @@ from datetime import datetime
 
 import urwid
 
+try:
+    from urwid_readline import ReadlineEdit
+    Edit = ReadlineEdit
+except ImportError:
+    Edit = urwid.Edit
+
 # #############################################################################
 # constants
 # #############################################################################
@@ -873,7 +879,7 @@ class LeftWindow(urwid.Frame):
     def __init__(self, state):
         self.state = state
         self._wcontacts = ContactsWindow(self.state)
-        self._wsearch = urwid.Edit(('bold', '> '))
+        self._wsearch = Edit(('bold', '> '))
 
         urwid.connect_signal(self._wsearch, 'postchange', self.on_search_text_changed)
 
@@ -929,7 +935,7 @@ class ChatWindow(urwid.Frame):
 
         self._wsearch = urwid.ListBox(self.search_list)
         self._wtitle = urwid.Text('')
-        self._wline = urwid.Edit(('bold', '> '))
+        self._wline = Edit(('bold', '> '))
         self._wdiv = urwid.Divider('-')
         self._wlist = urwid.ListBox(self.state.current_chat)
 


### PR DESCRIPTION
[urwid_readline](https://github.com/rr-/urwid_readline) has a `ReadlineEdit` class which is a drop-in replacement for `urwid.Edit`, but featuring readline-style keybinds.
With this change we make use of urwid_readline if the module is available.