### PR TITLE
do not strip group names in filter

### DIFF
--- a/scli
+++ b/scli
@@ -675,7 +675,7 @@ class Signal:
     def groups(self):
         # Need to filter out any groups that where "active" == false
         return list(filter(lambda a: bool(a['active']),
-                    (filter(lambda n: bool(n['name'].strip(' ')),
+                    (filter(lambda n: bool(n['name']),
                      self._data["groupStore"]['groups']))))
 
     def get_contact(self, number_or_id):


### PR DESCRIPTION
The groups' getter filters by status and name. When a group's name is
`None` (which can be), stripping the name raises an `AttributeError`
exception. Since we cast the name to bool for filtering, it is not
necessary to strip the name.