### PR TITLE
Remove temporary files created by scli

### DIFF
--- a/scli
+++ b/scli
@@ -470,7 +470,7 @@ class clip:
                     if mtype.startswith('image/'):
                         content = clip.xrun(mtype)
                         suffix = '.' + mtype.split('/')[1]
-                        tmp = tempfile.NamedTemporaryFile(mode='w+b', suffix=suffix, delete=False)
+                        tmp = tempfile.NamedTemporaryFile(mode='w+b', prefix='_scli-tmp.', suffix=suffix, delete=False)
                         tmp.write(content)
                         tmp.flush()
                         tmp.close()
@@ -533,7 +533,7 @@ class Commands:
         if args and len(args) == 1 and (args[0].startswith("/") or args[0].startswith("~/")):
             msg_file_path = os.path.expanduser(args[0])
         else:
-            msg_file_path = tempfile.NamedTemporaryFile(suffix='.md', delete=False).name
+            msg_file_path = tmpfile = tempfile.NamedTemporaryFile(suffix='.md', delete=False).name
             if args:
                 with open(msg_file_path, "w") as msg_file:
                     msg_file.write(' '.join(args))
@@ -547,6 +547,11 @@ class Commands:
             msg = msg_file.read().strip()
             if msg:
                 self.state.signal.send_message(self.state.current_contact, msg)
+
+        try:
+            os.remove(tmpfile)
+        except NameError:
+            pass
 
     def open_file(self, path):
         if os.path.exists(path):
@@ -575,6 +580,9 @@ class Commands:
 
         if files:
             self.state.signal.send_message(self.state.current_contact, message, files)
+            if files[0].startswith(
+                    os.path.join(tempfile.gettempdir(), '_scli-tmp.')):
+                os.remove(files[0])
         else:
             self.state.set_notification('Clipboard is empty.')
 


### PR DESCRIPTION
Cleans up the temporary files created by `external_edit()` and `attach_clip()` after they are no longer needed.

Currently the temp files are created with `tempfile.NamedTemporaryFile(.., delete=False)` but not removed afterwards. This patch uses `os.remove()` to delete the temp files. It makes sure only the files that were created by scli itself are deleted. (Both of the functions above can also be used with user-provided filenames, so we need to double-check that we're indeed deleting a temp file). This is more straightforward in `external_edit()`, where the temp file can be removed at the end of the same function where it is created (same name scope); less so in `attach_clip()` because the temp file is actually created in a different name scope (`clip.xfiles`). One solution for that would be creating a global variable (e.g. `TEMPFILES`) to keep track of all temp files created, but probably a less intrusive way is to just check the filename before deleting, and if it's sufficiently distinct trust that it's a scli-created temp file, which is what is used here.

P.S. Thanks for the nice signal interface!
