### PR TITLE
Make attach_clip work with background send

### DIFF
--- a/scli
+++ b/scli
@@ -445,6 +445,7 @@ class HelpDialog(urwid.ListBox):
 
 class clip:
     mime_order = ['image/png', 'image/jpeg', 'image/jpg', 'text/uri-list']
+    tempfile_prefix = '_scli-tmp.'
 
     @staticmethod
     def xrun(mime):
@@ -471,7 +472,7 @@ class clip:
                     if mtype.startswith('image/'):
                         content = clip.xrun(mtype)
                         suffix = '.' + mtype.split('/')[1]
-                        tmp = tempfile.NamedTemporaryFile(mode='w+b', prefix='_scli-tmp.', suffix=suffix, delete=False)
+                        tmp = tempfile.NamedTemporaryFile(mode='w+b', prefix=clip.tempfile_prefix, suffix=suffix, delete=False)
                         tmp.write(content)
                         tmp.flush()
                         tmp.close()
@@ -581,9 +582,6 @@ class Commands:
 
         if files:
             self.state.signal.send_message(self.state.current_contact, message, files)
-            if files[0].startswith(
-                    os.path.join(tempfile.gettempdir(), '_scli-tmp.')):
-                os.remove(files[0])
         else:
             self.state.set_notification('Clipboard is empty.')
 
@@ -752,6 +750,10 @@ class Signal:
         proc_pid, return_code = [int(i) for i in line.decode().split()]
         send_proc, watchpipe_fd, envelope = self.sending_procs.pop(proc_pid)
         send_proc.wait()  # reap the child process, to prevent zombies
+        for attachment in envelope['dataMessage']['attachments']:
+            if attachment.startswith(
+                    os.path.join(tempfile.gettempdir(), clip.tempfile_prefix)):
+                os.remove(attachment)
         if return_code != 0:
             logging.error('send_message: exit code=%d:err=%s', return_code, send_proc.stderr.read())
             # https://github.com/AsamK/signal-cli/issues/73


### PR DESCRIPTION
Postpone removing attached temporary files until the singal-cli
background send process finishes.

The combination of two of my previous commits ([background-send](https://github.com/isamert/scli/pull/56) and [tempfiles-cleanup](https://github.com/isamert/scli/pull/50)) broke `attach_clip()`: the attached temporary files that are created in `attach_clip()` get deleted right after the `send_message()` command returns. But now it returns instantly, relegating all the work to the signal-cli background process, so the tempfiles get deleted before signal-cli gets a chance to send them. 
This fixes it by moving the check for temp files to the handler function that is called when signal-cli send process exits. Sorry this did not get discovered in testing for the original commit! 
