### PR TITLE
Messages with attachments and no text

### DIFF
--- a/scli
+++ b/scli
@@ -882,8 +882,7 @@ class ContactsWindow(urwid.ListBox):
 
     def on_receive_message(self, envelope):
         contact = get_envelope_contact(envelope, self.state.signal)
-        has_msg = get_envelope_msg(envelope)
-        if contact == self.state.current_contact or not has_msg:
+        if contact == self.state.current_contact or get_envelope_msg(envelope) is None:
             return
 
         for w in self._body:

--- a/scli
+++ b/scli
@@ -224,9 +224,9 @@ def is_envelope_group_message(envelope):
 def get_envelope_msg(envelope):
     try:
         if envelope['dataMessage'] is not None:
-            return envelope['dataMessage']['message']
+            return envelope['dataMessage']['message'] or ''
         if envelope['syncMessage'] is not None:
-            return envelope['syncMessage']['sentMessage']['message']
+            return envelope['syncMessage']['sentMessage']['message'] or ''
         else:
             return None
     except (KeyError, TypeError):


### PR DESCRIPTION
Fix: display messages with attachments and no text (signal-cli 0.6.8)
signal-cli v0.6.8 represents empty-text in envelopes with `'message': null` instead of `'message': ''`.
Fixes #65.

Fix unread count unchanged on receive of no-text attachment
