### PR TITLE
Device linking changes

### DIFF
--- a/scli
+++ b/scli
@@ -2289,37 +2289,38 @@ class DeliveryStatus:
 # #############################################################################
 
 def link_device(device_name):
-    import pyqrcode
-    cmd_link = 'signal-cli link -n "{}"'.format(device_name)
-    pipe_link = Popen(cmd_link, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        import pyqrcode
+    except ImportError:
+        sys.exit("Error: `pyqrcode` module not found. Please install it with `pip install pyqrcode`")
+    print("Retrieving QR code, please wait...")
+    cmd_link = ['signal-cli', 'link', '-n', device_name]
+    pipe_link = Popen(cmd_link, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     line = pipe_link.stdout.readline().strip()
 
     if line.startswith('tsdevice:/'):
-        url = pyqrcode.create(line)
-        print(url.terminal(quiet_zone=1))
+        qr = pyqrcode.create(line, version=10)
+        print(qr.terminal(module_color='black', background='white'))
     else:
-        print('Encountered an error while linking: {}'.format(line))
-        sys.exit(1)
+        sys.exit('Encountered an error while linking: \n{}\n{}'.format(line, pipe_link.stderr.read()))
 
-    print('Linking... Please wait...')
+    print('Scan the QR code with Signal app on your phone and wait for the linking process to finish. This may take a moment...')
 
     pipe_link.wait()
     if pipe_link.returncode != 0:
-        print('Something went wrong while linking.')
-        sys.exit(pipe_link.returncode)
+        sys.exit('Something went wrong while linking: {}'.format(pipe_link.stderr.read()))
 
     print('Receiving data for the first time...')
 
-    cmd_receive = 'signal-cli -u "{}" receive'.format(detect_user_name())
-    pipe_receive = Popen(cmd_receive, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    cmd_receive = 'signal-cli -u {} receive'.format(detect_user_name())
+    pipe_receive = Popen(cmd_receive.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
     for receive_out in iter(pipe_receive.stdout.readline, ''):
         print(receive_out, end='')
 
     pipe_receive.wait()
     if pipe_receive.returncode != 0:
-        print('Something went wrong receiving.')
-        sys.exit(pipe_receive.returncode)
+        sys.exit('Something went wrong receiving: {}'.format(pipe_receive.stderr.read()))
 
     print('Done.')
     sys.exit(0)


### PR DESCRIPTION
I've opened this as a Pull Request to write the comments here. 

BTW, there is a new "Discussions" function on github, but it needs to be enabled for the repo. Might be worthwhile to have discussions conveniently right here in GH without creating new issues or PRs.

---

Having device liking in scli itself is great!

Some changes I've made here:

- I have a "light" colorscheme on my terminal, and the inverted-colors QR image that pyqrcode's `terminal()` produces by default, my phone refused to scan. I guess if you have a "dark" colorscheme, the resulting QR code looked normal with the default settings (black on white background).
	Also, added `version=10` for the QR code, apparently might be required for 'newer' versions of android: 
	https://github.com/AsamK/signal-cli/wiki/Linking-other-devices-(Provisioning)

- Replaced `Popen(cmd, shell=True)` with `Popen(cmd.split())`, to remove the possibility of getting shell symbols in `cmd`.

- Added / edited some printout messages. Added `stderr` printouts to error messages.
