### PR TITLE
Send asynchronous notifications

### DIFF
--- a/scli
+++ b/scli
@@ -1035,7 +1035,7 @@ class Commands:
 
     def send_notification(self, sender, message):
         if self.state.cfg.enable_notifications:
-            mk_call(self.state.cfg.notification_command, {'%s': sender, '%m': message})
+            mk_call(self.state.cfg.notification_command, {'%s': sender, '%m': message}, disown=True)
 
     def rename_contact(self, args):
         # :renameContact +NUMBER new name here  -> use +NUMBER number


### PR DESCRIPTION
Notifications that take time to complete [1] can block scli for a short
time.  If a user sends many messages in a short period of time, this can
block scli even longer.  This change makes notification run in the
background.

[1] E.G. notification-command=/usr/local/bin/flite 'Signal from %s'