### PR TITLE
mention config file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ There is a built-in search feature. Simply hit `/` while you are on the chat win
 For searching through contacts, you need to hit `/` while you are on the contacts window and start typing, contacts will be filtered out while you are typing. Hit `enter` to focus the results. Hitting `Esc` will clear the search.
 
 ## Configuration
-There are some simple configuration options. You can either pass them as command-line arguments or add them to your configuration file. Run `scli --help` to see all options. 
+There are some simple configuration options. You can either pass them as command-line arguments or add them to your configuration file `~/.config/sclirc`. Run `scli --help` to see all options.
 
 Configuration file syntax is also pretty easy. Lines starting with `#` and empty lines are ignored, other lines are `key = value` pairs. Optional arguments (flags) like `--debug`, can be enabled in config file with any of: `true`, `t`, `yes`, `y` (with any capitalization, case insensitive).
 


### PR DESCRIPTION
The README doesn't currently mention where the config file is supposed to be. Add a mention of it.