### PR TITLE
Update VERSION to make us of %(describe) instead of %d

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-$Format:%h %d$
+$Format:%h %(describe:match=v*)$
 
 
 # The format string above is expanded with values during the execution of

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-$Format:%h %(describe:match=v*)$
+$Format:%(describe:match=v*)$
 
 
 # The format string above is expanded with values during the execution of

--- a/scli
+++ b/scli
@@ -140,10 +140,11 @@ def get_version():
             version_str = f.readline()
     except OSError:
         return '?'
-    if version_str.startswith('$'):
-        # Neither a release, nor is there a `.git` dir (e.g. manually dl'ed blob)
+    if not version_str.startswith('v'):
+        # '$Format:...' - not a `git archive` (e.g. a manually dl'ed blob)
+        # '%(..)' - `git archive` if git < 2.32
         return '?'
-    return version_str.split()[-1] # tag or commit hash
+    return version_str[1:]  # `git-describe`-like string
 
 
 def get_default_editor():

--- a/scli
+++ b/scli
@@ -143,12 +143,7 @@ def get_version():
     if version_str.startswith('$'):
         # Neither a release, nor is there a `.git` dir (e.g. manually dl'ed blob)
         return '?'
-    tag_re = re.compile(r"tag: v(.+?)[,)]")
-        # Assumes VERSION file is formatted with `$Format:%h %d$`
-    tag_re_match = tag_re.search(version_str)
-    if tag_re_match:
-        return tag_re_match.group(1)
-    return version_str.split(maxsplit=1)[0]   # commit hash
+    return version_str.split()[-1] # tag or commit hash
 
 
 def get_default_editor():


### PR DESCRIPTION
This should make auto-generated tarballs more stable, which helps
packagers.

Fixes #151