### PR TITLE
Ring terminal bell on notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Commands can be entered by typing `:` following one of the commands below.
 - `:openUrl` or `:u` opens the last URL in conversation, if there is one.
 - `:openAttach` or `:o` opens the last attachment in conversation, if there is one.
 - `:toggleNotifications` or `:n` toggles desktop notifications.
+- `:toggleNotificationsBell` or `:b` toggles terminal bell on notifications.
 - `:toggleContactsSort` or `:s` toggles between sorting contacts alphabetically and by the most recent message.
 - `:toggleAutohide` or `:h` hides the contacts pane when it's not in focus.
 - `:addContact NUMBER [NAME]` adds a new contact to the contact list. Added contacts' names are local (not synced with signal servers).  

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Commands can be entered by typing `:` following one of the commands below.
 - `:openUrl` or `:u` opens the last URL in conversation, if there is one.
 - `:openAttach` or `:o` opens the last attachment in conversation, if there is one.
 - `:toggleNotifications` or `:n` toggles desktop notifications.
-- `:toggleNotificationsBell` or `:b` toggles terminal bell on notifications.
 - `:toggleContactsSort` or `:s` toggles between sorting contacts alphabetically and by the most recent message.
 - `:toggleAutohide` or `:h` hides the contacts pane when it's not in focus.
 - `:addContact NUMBER [NAME]` adds a new contact to the contact list. Added contacts' names are local (not synced with signal servers).  

--- a/scli
+++ b/scli
@@ -3943,7 +3943,6 @@ class Commands:
             (['openAttach', 'o'], self._actions.open_last_attach),
             (['openUrl', 'u'], self._actions.open_last_url),
             (['toggleNotifications', 'n'], self._actions.toggle_notifications),
-            (['toggleNotificationsBell', 'b'], self._actions.toggle_notifications_bell),
             (['toggleAutohide', 'h'], self._actions.toggle_autohide),
             (['toggleContactsSort', 's'], self._actions.toggle_sort_contacts),
             (['renameContact'], self._actions.rename_contact),
@@ -4021,8 +4020,6 @@ class Actions:
             return None
 
     def send_desktop_notification(self, sender, message):
-        if cfg.enable_notifications_bell:
-            print('\a', end='')
         if not cfg.enable_notifications:
             return
         rmap = {}
@@ -4031,6 +4028,8 @@ class Actions:
             rmap[token] = text
         rmap['_optionals'] = ('%s', '%m')
         self.callf(cfg.notification_command, rmap, background=True)
+        if not cfg.notification_no_bell:
+            print('\a', end='')
 
     def send_message_curr_contact(self, message="", attachments=None):
         if self._chats_data.current_contact is None:
@@ -4188,17 +4187,8 @@ class Actions:
                 '.'
                 ))
         self.set_status_line(notif)
-
-    def toggle_notifications_bell(self):
-        cfg.enable_notifications_bell = not cfg.enable_notifications_bell
-        notif = ''.join((
-                'Terminal bell on notifications is ',
-                'ON' if cfg.enable_notifications_bell else 'OFF',
-                '.'
-                ))
-        self.set_status_line(notif)
-
     # pylint: enable=attribute-defined-outside-init
+
     def add_contact(self, args):
         """Add a new contact.
 
@@ -4805,17 +4795,16 @@ def make_arg_parser():
     )
 
     parser.add_argument(
-        '-b',
-        '--enable-notifications-bell',
-        action='store_true',
-        help='Enable terminal bell on notifications. (Also see --enable-notifications)',
-    )
-
-    parser.add_argument(
         '-n',
         '--enable-notifications',
         action='store_true',
         help='Enable desktop notifications. (Also see --notification-command)',
+    )
+
+    parser.add_argument(
+        '--notification-no-bell',
+        action='store_true',
+        help="Do not send a \"bell\" code to the terminal on notification. It sets the terminal window's urgency hint, making it more noticable. (The exact visual effect depends on the terminal emulator and the window manager)",
     )
 
     parser.add_argument(

--- a/scli
+++ b/scli
@@ -3943,6 +3943,7 @@ class Commands:
             (['openAttach', 'o'], self._actions.open_last_attach),
             (['openUrl', 'u'], self._actions.open_last_url),
             (['toggleNotifications', 'n'], self._actions.toggle_notifications),
+            (['toggleNotificationsBell', 'b'], self._actions.toggle_notifications_bell),
             (['toggleAutohide', 'h'], self._actions.toggle_autohide),
             (['toggleContactsSort', 's'], self._actions.toggle_sort_contacts),
             (['renameContact'], self._actions.rename_contact),
@@ -4020,6 +4021,8 @@ class Actions:
             return None
 
     def send_desktop_notification(self, sender, message):
+        if cfg.enable_notifications_bell:
+            print('\a', end='')
         if not cfg.enable_notifications:
             return
         rmap = {}
@@ -4028,7 +4031,6 @@ class Actions:
             rmap[token] = text
         rmap['_optionals'] = ('%s', '%m')
         self.callf(cfg.notification_command, rmap, background=True)
-        print('\a')
 
     def send_message_curr_contact(self, message="", attachments=None):
         if self._chats_data.current_contact is None:
@@ -4186,8 +4188,17 @@ class Actions:
                 '.'
                 ))
         self.set_status_line(notif)
-    # pylint: enable=attribute-defined-outside-init
 
+    def toggle_notifications_bell(self):
+        cfg.enable_notifications_bell = not cfg.enable_notifications_bell
+        notif = ''.join((
+                'Terminal bell on notifications is ',
+                'ON' if cfg.enable_notifications_bell else 'OFF',
+                '.'
+                ))
+        self.set_status_line(notif)
+
+    # pylint: enable=attribute-defined-outside-init
     def add_contact(self, args):
         """Add a new contact.
 
@@ -4791,6 +4802,13 @@ def make_arg_parser():
         '--log-file',
         default=SCLI_LOG_FILE,
         help='Path to the log file. If not explicitly specified, logs are written only if `--debug` or `--save-history` are on.',
+    )
+
+    parser.add_argument(
+        '-b',
+        '--enable-notifications-bell',
+        action='store_true',
+        help='Enable terminal bell on notifications. (Also see --enable-notifications)',
     )
 
     parser.add_argument(

--- a/scli
+++ b/scli
@@ -4028,6 +4028,7 @@ class Actions:
             rmap[token] = text
         rmap['_optionals'] = ('%s', '%m')
         self.callf(cfg.notification_command, rmap, background=True)
+        print('\a')
 
     def send_message_curr_contact(self, message="", attachments=None):
         if self._chats_data.current_contact is None:


### PR DESCRIPTION
This simple change makes terminal ring a bell when sending a notification.

There is typically two things that can happen:

- An audible sound (can be disabled in terminal config)
- An urgency hint (mark window as needs attention)

The second item is my personal motivation for this PR. It makes of a very nice integration with Desktop Environment, when I not only get a notification, but also i3/sway can highlight which workspace sent the notification, and not only that, but there are common tools that can bring you directly to the window that requires attention.

Signal Desktop also sets this urgency hint on their window on notification (which due to electron issue is broken on Wayland, so `scli` will become superior 🙌 ).

If terminal is in focus, the urgency hint is basically a noop (but not the sound, if user has a sound configured).

I thought of maybe introducing a separate configuration for this, but then decided against this - notification and urgency hint often come hand-in-hand in other apps, and if user wants to disable them, they likely disable both.

Let me know what you think!