### PR TITLE
Show sender avatar in notifications

### DIFF
--- a/scli
+++ b/scli
@@ -1150,6 +1150,7 @@ class Contact:
 
     def __init__(self, record):
         self._record = record
+        self.avatar = self._get_avatar_file_path()
         if self.is_group:
             self.members_ids = set()
             self.member_contacts = set()
@@ -1160,6 +1161,22 @@ class Contact:
 
     def update_record(self, update_dict):
         self._record.update(update_dict)
+
+    def _get_avatar_file_path(self):
+        # Might be implemented in the future by signal-cli: https://github.com/AsamK/signal-cli/issues/869
+        def get_path(file_prefix, contact_id):
+            path = os.path.join(
+                    SIGNALCLI_AVATARS_FOLDER,
+                    f'{file_prefix}-{contact_id}',
+                    )
+            return path if os.path.exists(path) else None
+        if self.is_group:
+            return get_path('group', self.id.replace("/", "_"))
+        for file_prefix in ('profile', 'contact'):
+            path = get_path(file_prefix, self.id)
+            if path is not None:
+                return path
+        return None
 
     @property
     def is_group(self):
@@ -1176,17 +1193,6 @@ class Contact:
     @property
     def name_or_id(self):
         return self.name or self.profile_name or self.id
-
-    @property
-    def avatar(self):
-        if self._avatar is None:
-            profile = os.path.join(SIGNALCLI_AVATARS_FOLDER, f"profile-{self.id}")
-            contact = os.path.join(SIGNALCLI_AVATARS_FOLDER, f"contact-{self.id}")
-            if os.path.exists(profile):
-                self._avatar = profile
-            elif os.path.exists(contact):
-                self._avatar = contact
-        return self._avatar
 
 
 class Contacts:
@@ -4070,7 +4076,7 @@ class Actions:
                     )
             return None
 
-    def send_desktop_notification(self, sender, message, avatar):
+    def send_desktop_notification(self, sender, message, avatar=None):
         if not cfg.enable_notifications:
             return
         if avatar is None:
@@ -4348,7 +4354,7 @@ class Actions:
 
     def show_new_msg_notifications(self, msg):
         sender_name = self.get_contact_name(msg.sender_num)
-        sender_avatar = self.get_contact_avatar(msg.sender_num)
+        contact_avatar = self._get_contact_avatar(msg.contact_id)
 
         try:
             *_, reaction_envelope = msg.reactions.values()  # the latest reaction envelope
@@ -4358,8 +4364,8 @@ class Actions:
             sender_name = self.get_contact_name(
                     get_envelope_sender_id(reaction_envelope)
                     )
-            sender_avatar = self.get_contact_avatar(
-                    get_envelope_sender_id(reaction_envelope)
+            contact_avatar = self._get_contact_avatar(
+                    get_envelope_contact_id(reaction_envelope)
                     )
 
         def get_msg_notif():
@@ -4413,7 +4419,7 @@ class Actions:
         except TypeError:
             return
         notif = textwrap.shorten(notif, 80)
-        self.send_desktop_notification(sender_name, msg_text, sender_avatar)
+        self.send_desktop_notification(sender_name, msg_text, contact_avatar)
         if (self._chats_data.current_contact is None
                 or msg.contact_id != self._chats_data.current_contact.id):
             self.set_status_line(notif)
@@ -4422,8 +4428,8 @@ class Actions:
         contact = self._contacts.get_by_id(contact_num)
         return contact.name_or_id if contact else contact_num
 
-    def get_contact_avatar(self, contact_num):
-        contact = self._contacts.get_by_id(contact_num)
+    def _get_contact_avatar(self, contact_id):
+        contact = self._contacts.get_by_id(contact_id)
         return contact.avatar if contact else None
 
     def check_cmd_for_current_contact(self, fn):
@@ -4816,7 +4822,7 @@ def make_arg_parser():
         '-N',
         '--notification-command',
         default="notify-send -i '%a' scli '%s - %m'",
-        help='Command to run when a new message arrives. %%m is replaced with the message, %%s is replaced with the sender.',
+        help="Command to run when a new message arrives. %%m is replaced with the message, %%s is replaced with the sender, %%a is replaced with the path to the contact's avatar file if it exists, or with \"scli\" otherwise.",
     )
 
     parser.add_argument(

--- a/scli
+++ b/scli
@@ -4629,6 +4629,9 @@ class Coordinate:
 
     def _on_receive_reaction(self, envelope):
         msg = self._add_reaction(envelope)
+        if is_envelope_outgoing(envelope):
+            # Do not show notificitions for sync messages from linked devices
+            return
         if msg is not None:
             self._on_new_message(msg)
             # Not focusing on the received reaction message (same behavior as signal-desktop)

--- a/scli
+++ b/scli
@@ -4358,6 +4358,9 @@ class Actions:
             sender_name = self.get_contact_name(
                     get_envelope_sender_id(reaction_envelope)
                     )
+            sender_avatar = self.get_contact_avatar(
+                    get_envelope_sender_id(reaction_envelope)
+                    )
 
         def get_msg_notif():
             if reaction_envelope is not None:

--- a/scli
+++ b/scli
@@ -46,6 +46,7 @@ SIGNALCLI_LEGACY_ATTACHMENT_FOLDER = os.path.join(SIGNALCLI_LEGACY_FOLDER, 'atta
 SIGNALCLI_FOLDER = os.path.join(DATA_FOLDER, 'signal-cli')
 SIGNALCLI_DATA_FOLDER = os.path.join(SIGNALCLI_FOLDER, 'data')
 SIGNALCLI_ATTACHMENT_FOLDER = os.path.join(SIGNALCLI_FOLDER, 'attachments')
+SIGNALCLI_AVATARS_FOLDER = os.path.join(SIGNALCLI_FOLDER, 'avatars')
 SIGNALCLI_STICKERS_FOLDER = os.path.join(SIGNALCLI_FOLDER, 'stickers')
 
 SCLI_DATA_FOLDER = os.path.join(DATA_FOLDER, 'scli')
@@ -1175,6 +1176,17 @@ class Contact:
     @property
     def name_or_id(self):
         return self.name or self.profile_name or self.id
+
+    @property
+    def avatar(self):
+        if self._avatar is None:
+            profile = os.path.join(SIGNALCLI_AVATARS_FOLDER, f"profile-{self.id}")
+            contact = os.path.join(SIGNALCLI_AVATARS_FOLDER, f"contact-{self.id}")
+            if os.path.exists(profile):
+                self._avatar = profile
+            elif os.path.exists(contact):
+                self._avatar = contact
+        return self._avatar
 
 
 class Contacts:
@@ -4058,11 +4070,13 @@ class Actions:
                     )
             return None
 
-    def send_desktop_notification(self, sender, message):
+    def send_desktop_notification(self, sender, message, avatar):
         if not cfg.enable_notifications:
             return
+        if avatar is None:
+            avatar = 'scli'
         rmap = {}
-        for token, text in (('%s', sender), ('%m', message)):
+        for token, text in (('%s', sender), ('%m', message), ('%a', avatar)):
             text = text.replace(r"'", r"'\''")
             rmap[token] = text
         rmap['_optionals'] = ('%s', '%m')
@@ -4334,6 +4348,7 @@ class Actions:
 
     def show_new_msg_notifications(self, msg):
         sender_name = self.get_contact_name(msg.sender_num)
+        sender_avatar = self.get_contact_avatar(msg.sender_num)
 
         try:
             *_, reaction_envelope = msg.reactions.values()  # the latest reaction envelope
@@ -4395,7 +4410,7 @@ class Actions:
         except TypeError:
             return
         notif = textwrap.shorten(notif, 80)
-        self.send_desktop_notification(sender_name, msg_text)
+        self.send_desktop_notification(sender_name, msg_text, sender_avatar)
         if (self._chats_data.current_contact is None
                 or msg.contact_id != self._chats_data.current_contact.id):
             self.set_status_line(notif)
@@ -4403,6 +4418,10 @@ class Actions:
     def get_contact_name(self, contact_num):
         contact = self._contacts.get_by_id(contact_num)
         return contact.name_or_id if contact else contact_num
+
+    def get_contact_avatar(self, contact_num):
+        contact = self._contacts.get_by_id(contact_num)
+        return contact.avatar if contact else None
 
     def check_cmd_for_current_contact(self, fn):
         return (
@@ -4793,7 +4812,7 @@ def make_arg_parser():
     parser.add_argument(
         '-N',
         '--notification-command',
-        default="notify-send scli '%s - %m'",
+        default="notify-send -i '%a' scli '%s - %m'",
         help='Command to run when a new message arrives. %%m is replaced with the message, %%s is replaced with the sender.',
     )
 


### PR DESCRIPTION
Fixes #159.

Things to note:

- Profile pic is preferred over contact pic, to replicate official client behavior
- When no avatar is found, we default to `scli` as I originally proposed, not to some existing freedesktop icon.

... Why?

This allows for maximum flexibility. If we were to default to say `mail-message-new`, two things might happen:

- Some people complain that they dont want any fallback icon, real avatar or nothing
- Other people complain that they want a different fallback icon, not this one

Both cases are not really possible to configure via `--notification-command`, as this is just a _fallback_ icon. We'd have to make an extra param or two to control this.

With the proposed default to `scli` however, everything above is achievable.

- Don't want any fallback icon? It's the default behavior!
- Want `mail-message-new` as a fallback? `ln -s mail-message-new.png scli.png`.
- Want a different fallback? Same as above!
- What if `scli` itself some day adds a nice cool logo? Users can copy it to icons dir, and it can serve as a default fallback.