### PR TITLE
Using GPG to encrypt plaintext history and attachments

### DIFF
--- a/scli.sh
+++ b/scli.sh
@@ -28,6 +28,10 @@ decrypt() {
         gpg --batch --yes --passphrase "$GPGPASSWD" --decrypt "$HOME/.local/share/scli/attachments.tar.gz.gpg" \
             | tar -xzf -
     fi
+    if [[ -f "$HOME/.local/share/signal-cli/data" ]]; then
+        gpg --batch --yes --passphrase "$GPGPASSWD" --decrypt "$HOME/.local/share/signal-cli/data.tar.gz.gpg" \
+            | tar -xzf -
+    fi
 }
 encrypt() {
     echo "Encrypting history:"
@@ -39,6 +43,10 @@ encrypt() {
             | gpg --batch --yes --passphrase "$GPGPASSWD" -c \
                 -o "$HOME/.local/share/scli/attachments.tar.gz.gpg" && \
             rm -r "$HOME/.local/share/scli/attachments" 
+        tar -cz "$HOME/.local/share/signal-cli/data" \
+            | gpg --batch --yes --passphrase "$GPGPASSWD" -c \
+                -o "$HOME/.local/share/signal-cli/data.tar.gz.gpg" && \
+            rm -r "$HOME/.local/share/signal-cli/data" 
     fi
 }
 trap encrypt EXIT

--- a/scli.sh
+++ b/scli.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SOURCE=${BASH_SOURCE[0]}
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+echo -n "Password: "
+read -s GPGPASSWD
+
+decrypt() {
+    if [[ -f "$HOME/.local/share/scli/history.gpg" ]]; then
+        gpg --batch --yes --passphrase "$GPGPASSWD" --decrypt "$HOME/.local/share/scli/history.gpg" > \
+            "$HOME/.local/share/scli/history" 
+    fi
+    if [[ -f "$HOME/.local/share/scli/attachments.gpg" ]]; then
+        gpg --batch --yes --passphrase "$GPGPASSWD" --decrypt "$HOME/.local/share/scli/attachments.tar.gz.gpg" \
+            | tar -xzf -
+    fi
+}
+encrypt() {
+    echo "Encrypting history:"
+    if [[ -f  "$HOME/.local/share/scli/history" ]]; then
+        gpg --batch --yes --passphrase "$GPGPASSWD" -c "$HOME/.local/share/scli/history" && \
+            rm "$HOME/.local/share/scli/history" && \
+            rm "$HOME/.local/share/scli/history.bak"
+        tar -cz "$HOME/.local/share/scli/attachments" \
+            | gpg --batch --yes --passphrase "$GPGPASSWD" -c \
+                -o "$HOME/.local/share/scli/attachments.tar.gz.gpg" && \
+            rm -r "$HOME/.local/share/scli/attachments" 
+    fi
+}
+trap encrypt EXIT
+decrypt
+"${DIR}/scli"

--- a/scli.sh
+++ b/scli.sh
@@ -8,11 +8,19 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
 
-echo -n "Password: "
-read -s GPGPASSWD
-
+prompt_password() {
+    echo -n "Password: "
+    read -s GPGPASSWD
+}
 decrypt() {
     if [[ -f "$HOME/.local/share/scli/history.gpg" ]]; then
+        test_password() {
+            gpg --batch --yes --dry-run --passphrase "$GPGPASSWD" --decrypt "$HOME/.local/share/scli/history.gpg" > /dev/null
+        }
+        while ! test_password; do
+            echo 'Bad password.'
+            prompt_password
+        done
         gpg --batch --yes --passphrase "$GPGPASSWD" --decrypt "$HOME/.local/share/scli/history.gpg" > \
             "$HOME/.local/share/scli/history" 
     fi
@@ -34,5 +42,6 @@ encrypt() {
     fi
 }
 trap encrypt EXIT
+prompt_password
 decrypt
 "${DIR}/scli"


### PR DESCRIPTION
Hello,

First of all, thank you for `scli`. The official app is unusable for me (can't start up most of the time, and will eat memory until the PC crashes), and `scli` filled that hole really elegantly. Really like the way the app is organized, too, in terms of the bindings and the on-screen navigation.

The one thing I was missing, however, was the history. I know that `scli` has support for persistent history, but it felt silly to use Signal, and then leak my contacts' messages onto a plain text file.

This PR attempts to fix that somewhat, by decrypting/encrypting the relevant history and attachment files at start-up/quit, using Gnu Privacy Guard.

This is done in a Bash script, currently (`scli.sh`), which leaves `scli` untouched, but (maybe?) reduces portability. I think it would be possible to integrate the behaviour into `scli`, but would like some feedback.

- Miguel