### PR TITLE
fix attribute typo

### DIFF
--- a/scli
+++ b/scli
@@ -657,7 +657,7 @@ class AsyncQueued(AsyncProc):
         except OSError:
             n_curr_fds = 32
         fd_limits = [nprocs*3+n_curr_fds]  # each proc opens 3 FDs
-        for res in (resource.RLIMIT_NOFILE, resource.RLIMIT_OFILE):
+        for res in (resource.RLIMIT_NOFILE, resource.RLIMIT_NOFILE):
             with suppress(OSError, ValueError):
                 fd_limits.append(resource.getrlimit(res)[0])
         return (min(fd_limits) - n_curr_fds) // 3


### PR DESCRIPTION
`scli` won't launch, and python helpfully told me what to do:

```
AttributeError: module 'resource' has no attribute 'RLIMIT_OFILE'. Did you mean: 'RLIMIT_NOFILE'?
```
