### PR TITLE
Support for escaping comment symbols in configuration file.

### DIFF
--- a/scli
+++ b/scli
@@ -5933,7 +5933,12 @@ def get_cfg_file_args(file_obj):
     # Alternatively, can override `ArgumentParser.convert_arg_line_to_args()`.
     ret = {}
     for line in file_obj:
+
+        # Remove content after the comment sign but allow escaping.
+        line = line.replace('\\#', 'ESCAPED_HASH_SIGN')
         line = line.split('#', 1)[0].strip()
+        line = line.replace('ESCAPED_HASH_SIGN', '#')
+
         if not line:
             continue
         try:


### PR DESCRIPTION
I wanted to color the incoming/outgoing messages using the config file instead of command arguments, like this:

```
save-history = true
debug = true
contacts-autohide = true
show-inline = true
one-sided = true
show-names = true
color = ["\#0aa", "\#bb0"]
```

But I ran into the problem that the `#` symbol which is used to specify colors precisely, conflicted with the same symbol being used to indicate a comment.

I thought of changing how colors were handled, i.e. by removing the `#` from color definitions, but that would be a software design decision that I felt uncomfortable making.

This allows hash symbols in configuration values by escaping them. It shouldn't break existing configurations.